### PR TITLE
chore(stylelint): change repo stylelint config to js

### DIFF
--- a/packages/config-stylelint/index.js
+++ b/packages/config-stylelint/index.js
@@ -1,5 +1,3 @@
-import type { Config } from "stylelint";
-
 // These are all the custom `@` (at) rules that we use within our custom PostCSS plugins
 const CUSTOM_AT_RULES = [
   // Tailwind-specific at-rules
@@ -31,6 +29,7 @@ const ONLY_ALLOW_CAMELCASE_SELECTORS = [
   { message: (s) => `Expected '${s}' to be in camelCase` },
 ];
 
+/** @type {import("stylelint").Config} */
 const config = {
   extends: ["stylelint-config-standard"],
   plugins: ["stylelint-order", "stylelint-selector-bem-pattern"],
@@ -105,6 +104,6 @@ const config = {
       },
     },
   ],
-} satisfies Config;
+};
 
 export default config;

--- a/packages/config-stylelint/package.json
+++ b/packages/config-stylelint/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "type": "module",
   "exports": {
-    ".": "./stylelint.config.ts"
+    ".": "./index.js"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",

--- a/packages/config-stylelint/tsconfig.json
+++ b/packages/config-stylelint/tsconfig.json
@@ -1,5 +1,0 @@
-{
-  "extends": "@repo/typescript-config/base.json",
-  "include": ["."],
-  "exclude": ["dist", "build", "node_modules"]
-}


### PR DESCRIPTION
* tired of the stylelint check failing in ci randomly
* kitchen sink example in turborepo does not use ts for ts and eslint configs